### PR TITLE
Enable AUTOINSTALL

### DIFF
--- a/broadcom-07.705.02.00/dkms.conf
+++ b/broadcom-07.705.02.00/dkms.conf
@@ -15,6 +15,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/scsi/megaraid/"
 MODULES_CONF_ALIAS_TYPE[0]="scsi_hostadapter"
 
 REMAKE_INITRD="yes"
+AUTOINSTALL="yes"
 
 #
 # Patches

--- a/broadcom-07.706.03.00/dkms.conf
+++ b/broadcom-07.706.03.00/dkms.conf
@@ -15,6 +15,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/scsi/megaraid/"
 MODULES_CONF_ALIAS_TYPE[0]="scsi_hostadapter"
 
 REMAKE_INITRD="yes"
+AUTOINSTALL="yes"
 
 #
 # Patches

--- a/dell-07.700.52.00/dkms.conf
+++ b/dell-07.700.52.00/dkms.conf
@@ -15,6 +15,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/scsi/megaraid/"
 MODULES_CONF_ALIAS_TYPE[0]="scsi_hostadapter"
 
 REMAKE_INITRD="yes"
+AUTOINSTALL="yes"
 
 #
 # Patches

--- a/dell-07.703.06.00/dkms.conf
+++ b/dell-07.703.06.00/dkms.conf
@@ -15,6 +15,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/scsi/megaraid/"
 MODULES_CONF_ALIAS_TYPE[0]="scsi_hostadapter"
 
 REMAKE_INITRD="yes"
+AUTOINSTALL="yes"
 
 #
 # Patches


### PR DESCRIPTION
This makes upgrading kernels safe with this DKMS. Otherwise, when we install a new kernel the module will not be automatically rebuilt and boot may fail.